### PR TITLE
make javatuples a valid OSGI bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.javatuples</groupId>
   <artifactId>javatuples</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <version>1.3-SNAPSHOT</version>
   <name>javatuples</name>
   <url>http://www.javatuples.org</url>
@@ -204,6 +204,12 @@
 
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.0.0</version>
+        <extensions>true</extensions>
+      </plugin>
 
     </plugins>
     


### PR DESCRIPTION
I need javatuples to be a valid OSGI bundle.
This pull request just adds the maven-bundle-plugin to the build process.