### PR TITLE
Add Map.Entry-like methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+#IntelliJ IDEA
+.idea/
+*.iml
+
+target/

--- a/src/main/java/org/javatuples/Pair.java
+++ b/src/main/java/org/javatuples/Pair.java
@@ -191,6 +191,9 @@ public final class Pair<A,B>
         return this.val1;
     }
 
+    public A getKey() { return getValue0(); }
+
+    public B getValue() { return getValue1(); }
 
     @Override
     public int getSize() {

--- a/src/test/java/org/javatuples/Test.java
+++ b/src/test/java/org/javatuples/Test.java
@@ -99,6 +99,8 @@ public class Test extends TestCase {
         assertTrue(pair.containsAll(o));
         assertTrue(pair.containsAll(null,"a"));
         assertTrue(!pair.containsAll(null,"b"));
+        assertEquals("a", pair.getKey());
+        assertEquals(null, pair.getValue());
         
         final byte[] serSextet = SerializationUtils.serialize(sextet);
         System.out.println(Arrays.asList(ArrayUtils.toObject(serSextet)));


### PR DESCRIPTION
In Java 11 [javafx.util.Pair](https://docs.oracle.com/javase/9/docs/api/javafx/util/Pair.html) is not longer part of JDK. We needed to replace it with something similar and javatuples Pair was a good option except it misses nice methods getKey() and getValue().
I think it will be beneficial for the class to have such methods.