### PR TITLE
Add an explicit module info via moditect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,34 @@
         <extensions>true</extensions>
       </plugin>
 
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.Final</version>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <jvmVersion>9</jvmVersion>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+              <module>
+                <moduleInfo>
+                  <name>org.javatuples</name>
+                  <exports>
+                    org.javatuples;
+                    org.javatuples.valueintf;
+                  </exports>
+                </moduleInfo>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
     
   </build>


### PR DESCRIPTION
This adds an explicit `module-info.class` to the final artifact as a multi-release jar.

This means Java 5 users will be unaffected, but those using Java 9+ will see the new file.

A stable module name, either automatic or this way, is needed for dependent libraries to add module-infos of their own. A real module-info is needed in every one of a user's dependencies for them to be able to use jlink.